### PR TITLE
docs: Put "required secrets" information in a table

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ A GitHub repository template for developing a new Terraform provider.
 
 The following secrets must be added to the GitHub repository:
 
--------------------------------------------------------------------------------
- Secret Name                   Description                                                                                      
------------------------------- ------------------------------------------------
- `GPG_PRIVATE_KEY`             The GPG private key used to sign provider 
-                               releases before publishing to the Terraform 
-                               registry. 
-
- `GPG_PRIVATE_KEY_PASSPHRASE`  The passphrase for the signing GPG private key.                                                 
+| Secret Name                  | Description                                 |                                                  
+| ---------------------------- | ------------------------------------------- |
+| `GPG_PRIVATE_KEY`            | The GPG private key used to sign provider   |
+|                              | releases before publishing to the Terraform |
+|                              | registry.                                   |
+|                              |                                             |
+| `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the signing GPG private  |
+|                              | key.                                        |                                                

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@ A GitHub repository template for developing a new Terraform provider.
 
 The following secrets must be added to the GitHub repository:
 
-| Secret Name                  | Description                                 |                                                  
-| ---------------------------- | ------------------------------------------- |
-| `GPG_PRIVATE_KEY`            | The GPG private key used to sign provider   |
-                                 releases before publishing to the Terraform  
-                                 registry.                                    
-| `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the signing GPG private  |
-                                 key.                                         
+| Secret Name                  | Description                                                                                     |
+| ---------------------------- | ----------------------------------------------------------------------------------------------- |
+| `GPG_PRIVATE_KEY`            | The GPG private key used to sign provider releases before publishing to the Terraform registry. |
+| `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the signing GPG private key.                                                 |

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # terraform-provider-template
+
 A GitHub repository template for developing a new Terraform provider.
 
 ## Required Secrets

--- a/README.md
+++ b/README.md
@@ -5,5 +5,11 @@ A GitHub repository template for developing a new Terraform provider.
 
 The following secrets must be added to the GitHub repository:
 
-`GPG_PRIVATE_KEY`: The GPG private key used to sign provider releases before publishing to the Terraform registry.
-`GPG_PRIVATE_KEY_PASSPHRASE`: The passphrase for the signing GPG private key.
+-------------------------------------------------------------------------------
+ Secret Name                   Description                                                                                      
+------------------------------ ------------------------------------------------
+ `GPG_PRIVATE_KEY`             The GPG private key used to sign provider 
+                               releases before publishing to the Terraform 
+                               registry. 
+
+ `GPG_PRIVATE_KEY_PASSPHRASE`  The passphrase for the signing GPG private key.                                                 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ The following secrets must be added to the GitHub repository:
 | Secret Name                  | Description                                 |                                                  
 | ---------------------------- | ------------------------------------------- |
 | `GPG_PRIVATE_KEY`            | The GPG private key used to sign provider   |
-|                              | releases before publishing to the Terraform |
-|                              | registry.                                   |
-|                              |                                             |
+                                 releases before publishing to the Terraform  
+                                 registry.                                    
 | `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the signing GPG private  |
-|                              | key.                                        |                                                
+                                 key.                                         

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ The following secrets must be added to the GitHub repository:
 | Secret Name                  | Description                                                                                     |
 | ---------------------------- | ----------------------------------------------------------------------------------------------- |
 | `GPG_PRIVATE_KEY`            | The GPG private key used to sign provider releases before publishing to the Terraform registry. |
-| `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the signing GPG private key.                                                 |
+| `GPG_PRIVATE_KEY_PASSPHRASE` | The passphrase for the GPG private signing key.                                                 |

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -88,4 +88,3 @@ func New(version string) func() provider.Provider {
 		}
 	}
 }
-


### PR DESCRIPTION
Update the README to capture the required GitHub secrets for this template in an easy to read table format.