### PR TITLE
chore: Update tool versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,7 +82,7 @@ jobs:
           go-version-file: go.mod
 
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.2.0
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.3.0
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Lint Go Files
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.11.4
+          version: v2.12.2
 
   tidy:
     name: Go Mod Tidy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
-          terraform_version: 1.14.8
+          terraform_version: 1.15.4
 
       - name: Lint Terraform Files
         run: |

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   title:
     name: Semantic Title
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # 6.1.1
         with:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PROVIDER_NAME         := terraform-provider-template
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
-GOLANGCI_LINT_VERSION := v2.11.4
+GOLANGCI_LINT_VERSION := v2.12.2
 GOVULNCHECK_VERSION   := v1.2.0
 TFPLUGINDOCS_VERSION  := v0.25.0
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROVIDER_NAME         := terraform-provider-template
 BUILD_DIR             := .local/builds
 PLATFORMS             := linux/amd64 linux/arm64 darwin/amd64 darwin/arm64
 GOLANGCI_LINT_VERSION := v2.12.2
-GOVULNCHECK_VERSION   := v1.2.0
+GOVULNCHECK_VERSION   := v1.3.0
 TFPLUGINDOCS_VERSION  := v0.25.0
 GO_VERSION := $(shell awk '/^go /{print $$2}' go.mod)
 


### PR DESCRIPTION
- Bump golangci-lint from v2.11.4 to v2.12.2 (Makefile + lint workflow).
- Bump govulncheck from v1.2.0 to v1.3.0 (Makefile + lint workflow).
- Bump terraform from 1.14.8 to 1.15.4 (lint workflow).
- Bump pre-release workflow runner from ubuntu-22.04 to ubuntu-24.04 to match the rest of the workflows.