### PR TITLE
chore(ci): Standardize Dependabot commit prefixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,11 @@ updates:
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(ci)
 
   - package-ecosystem: gomod
     directory: /
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore
+      prefix: chore(deps)


### PR DESCRIPTION
- Standardize the Dependabot `commit-message.prefix` to the lab's scope-by-area scheme.
- `github-actions` updates use `chore(ci)`; `gomod` updates use `chore(deps)`.
- Commit type stays `chore`, so dependency bumps still never trigger a release.