### PR TITLE
fix: Bump Go to 1.25.11

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/craigsloggett-lab/terraform-provider-template
 
-go 1.25.10
+go 1.25.11
 
 require (
 	github.com/hashicorp/terraform-plugin-framework v1.19.0


### PR DESCRIPTION
- Bump the `go` directive in `go.mod` from 1.25.10 to 1.25.11 so CI installs the patched toolchain.
- Addresses GO-2026-5039 (`net/textproto`: arbitrary inputs in errors without escaping), fixed in go1.25.11.
- Addresses GO-2026-5037 (`crypto/x509`: inefficient candidate hostname parsing), fixed in go1.25.11.
- Stdlib-only fix, so no dependency or `go.sum` change is required.
- Resolves the failing Vulnerability Check on open PRs; other open PRs clear it after rebasing on `main`.